### PR TITLE
Add API identifiers to pricing records

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -153,7 +153,8 @@ Each model in the pricing data follows this structure:
       "Output": "Output pricing",
       // ... other fields
     },
-    "source": "https://provider.com/pricing"
+    "source": "https://provider.com/pricing",
+    "api_identifier": "provider"
   }
 }
 ```
@@ -161,6 +162,7 @@ Each model in the pricing data follows this structure:
 ### Common Pricing Fields
 While the exact structure varies by provider, common fields include:
 
+- `api_identifier`: Provider's API identifier
 - `Model`: Model name/identifier
 - `Input`: Input token pricing
 - `Output`: Output token pricing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pricing Service
 
-This service scrapes model pricing information from various providers and serves it over a FastAPI server.
+This service scrapes model pricing information from various providers and serves it over a FastAPI server. Each pricing record includes an `api_identifier` field that names the provider's API so other applications can associate models with their source service.
 
 ## Running
 

--- a/agents.md
+++ b/agents.md
@@ -37,8 +37,9 @@ lando-pricemaster/
 
 **Scraper Modules**: Located in `src/pricing_service/scrapers/`
 - Each module must implement a `fetch_prices()` function
+- Each module defines an `API_IDENTIFIER` constant naming the provider
 - Returns a dictionary with model IDs as keys
-- Expected format: `{model_id: {"raw": data, "source": url}}`
+- Expected format: `{model_id: {"raw": data, "source": url, "api_identifier": API_IDENTIFIER}}`
 
 ### 2. FastAPI Server (`server.py`)
 

--- a/data/model_pricing.json
+++ b/data/model_pricing.json
@@ -6,7 +6,8 @@
       "Price per hour": "$1.89/h",
       "Price per second": "$0.0005/s"
     },
-    "source": "https://fal.ai/pricing"
+    "source": "https://fal.ai/pricing",
+    "api_identifier": "fal"
   },
   "H200": {
     "raw": {
@@ -15,7 +16,8 @@
       "Price per hour": "$2.10/h",
       "Price per second": "$0.0006/s"
     },
-    "source": "https://fal.ai/pricing"
+    "source": "https://fal.ai/pricing",
+    "api_identifier": "fal"
   },
   "A100": {
     "raw": {
@@ -24,7 +26,8 @@
       "Price per hour": "$0.99/h",
       "Price per second": "$0.0003/s"
     },
-    "source": "https://fal.ai/pricing"
+    "source": "https://fal.ai/pricing",
+    "api_identifier": "fal"
   },
   "B200": {
     "raw": {
@@ -33,7 +36,8 @@
       "Price per hour": "contact us",
       "Price per second": "contact us"
     },
-    "source": "https://fal.ai/pricing"
+    "source": "https://fal.ai/pricing",
+    "api_identifier": "fal"
   },
   "Hunyuan Video": {
     "raw": {
@@ -43,6 +47,7 @@
       "Output per $1": "3videos"
     },
     "source": "https://fal.ai/pricing",
+    "api_identifier": "fal",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -56,6 +61,7 @@
       "Output per $1": "11video seconds"
     },
     "source": "https://fal.ai/pricing",
+    "api_identifier": "fal",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -69,6 +75,7 @@
       "Output per $1": "4video seconds"
     },
     "source": "https://fal.ai/pricing",
+    "api_identifier": "fal",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -82,6 +89,7 @@
       "Output per $1": "3videos"
     },
     "source": "https://fal.ai/pricing",
+    "api_identifier": "fal",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -95,6 +103,7 @@
       "Output per $1": "2videos"
     },
     "source": "https://fal.ai/pricing",
+    "api_identifier": "fal",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -108,6 +117,7 @@
       "Output per $1": "50video seconds"
     },
     "source": "https://fal.ai/pricing",
+    "api_identifier": "fal",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -122,7 +132,8 @@
     "modalities": [
       "text-to-video",
       "image-to-video"
-    ]
+    ],
+    "api_identifier": "runway"
   },
   "runway-standard": {
     "raw": {
@@ -135,7 +146,8 @@
     "modalities": [
       "text-to-video",
       "image-to-video"
-    ]
+    ],
+    "api_identifier": "runway"
   },
   "runway-pro": {
     "raw": {
@@ -148,7 +160,8 @@
     "modalities": [
       "text-to-video",
       "image-to-video"
-    ]
+    ],
+    "api_identifier": "runway"
   },
   "runway-team": {
     "raw": {
@@ -159,7 +172,8 @@
     "modalities": [
       "text-to-video",
       "image-to-video"
-    ]
+    ],
+    "api_identifier": "runway"
   },
   "hedra": {
     "raw": {
@@ -169,7 +183,8 @@
     "modalities": [
       "speech-to-video",
       "text-to-video"
-    ]
+    ],
+    "api_identifier": "hedra"
   },
   "elevenlabs-free": {
     "raw": {
@@ -181,7 +196,8 @@
     "modalities": [
       "text-to-speech",
       "speech-to-speech"
-    ]
+    ],
+    "api_identifier": "elevenlabs"
   },
   "elevenlabs-starter": {
     "raw": {
@@ -193,7 +209,8 @@
     "modalities": [
       "text-to-speech",
       "speech-to-speech"
-    ]
+    ],
+    "api_identifier": "elevenlabs"
   },
   "elevenlabs-creator": {
     "raw": {
@@ -205,7 +222,8 @@
     "modalities": [
       "text-to-speech",
       "speech-to-speech"
-    ]
+    ],
+    "api_identifier": "elevenlabs"
   },
   "elevenlabs-pro": {
     "raw": {
@@ -217,7 +235,8 @@
     "modalities": [
       "text-to-speech",
       "speech-to-speech"
-    ]
+    ],
+    "api_identifier": "elevenlabs"
   },
   "elevenlabs-scale": {
     "raw": {
@@ -228,7 +247,8 @@
     "modalities": [
       "text-to-speech",
       "speech-to-speech"
-    ]
+    ],
+    "api_identifier": "elevenlabs"
   },
   "elevenlabs-business": {
     "raw": {
@@ -239,7 +259,8 @@
     "modalities": [
       "text-to-speech",
       "speech-to-speech"
-    ]
+    ],
+    "api_identifier": "elevenlabs"
   },
   "Gemini 2.5 Pro": {
     "raw": {
@@ -270,7 +291,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.5 Flash": {
     "raw": {
@@ -305,7 +327,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.5 Flash-Lite": {
     "raw": {
@@ -336,7 +359,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.5 Flash Native Audio": {
     "raw": {
@@ -359,7 +383,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.5 Flash Image Preview": {
     "raw": {
@@ -382,7 +407,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.5 Flash Preview TTS": {
     "raw": {
@@ -405,7 +431,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.5 Pro Preview TTS": {
     "raw": {
@@ -428,7 +455,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.0 Flash": {
     "raw": {
@@ -475,7 +503,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 2.0 Flash-Lite": {
     "raw": {
@@ -514,7 +543,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Imagen 4": {
     "raw": {
@@ -541,7 +571,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Imagen 3": {
     "raw": {
@@ -560,7 +591,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Veo 3 Preview": {
     "raw": {
@@ -579,7 +611,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Veo 3 Fast Preview": {
     "raw": {
@@ -598,7 +631,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Veo 2": {
     "raw": {
@@ -617,7 +651,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini Embedding": {
     "raw": {
@@ -636,7 +671,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemma 3": {
     "raw": {
@@ -675,7 +711,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemma 3n": {
     "raw": {
@@ -714,7 +751,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 1.5 Flash": {
     "raw": {
@@ -753,7 +791,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 1.5 Flash-8B": {
     "raw": {
@@ -792,7 +831,8 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   },
   "Gemini 1.5 Pro": {
     "raw": {
@@ -831,6 +871,7 @@
       "image-to-text",
       "audio-to-text",
       "video-to-text"
-    ]
+    ],
+    "api_identifier": "gemini"
   }
 }

--- a/src/pricing_service/scrapers/elevenlabs.py
+++ b/src/pricing_service/scrapers/elevenlabs.py
@@ -8,6 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 ELEVENLABS_PRICING_URL = "https://elevenlabs.io/pricing"
+API_IDENTIFIER = "elevenlabs"
 
 PLAN_ORDER = ["Free", "Starter", "Creator", "Pro", "Scale", "Business"]
 
@@ -44,5 +45,6 @@ def fetch_prices() -> Dict[str, Dict]:
             "raw": info,
             "source": ELEVENLABS_PRICING_URL,
             "modalities": ["text-to-speech", "speech-to-speech"],
+            "api_identifier": API_IDENTIFIER,
         }
     return data

--- a/src/pricing_service/scrapers/fal.py
+++ b/src/pricing_service/scrapers/fal.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 import requests
 
 FAL_PRICING_URL = "https://fal.ai/pricing"
+API_IDENTIFIER = "fal"
 
 # Known model modalities for fal.ai hosted models. These models primarily
 # generate video and generally support both text and image prompting.
@@ -49,14 +50,22 @@ def fetch_prices() -> dict:
     for record in _parse_table(tables[0]):
         model_id = record.get("GPU")
         if model_id:
-            data[model_id] = {"raw": record, "source": FAL_PRICING_URL}
+            data[model_id] = {
+                "raw": record,
+                "source": FAL_PRICING_URL,
+                "api_identifier": API_IDENTIFIER,
+            }
 
     # Model pricing (second table)
     if len(tables) > 1:
         for record in _parse_table(tables[1]):
             model_id = record.get("Model")
             if model_id:
-                data[model_id] = {"raw": record, "source": FAL_PRICING_URL}
+                data[model_id] = {
+                    "raw": record,
+                    "source": FAL_PRICING_URL,
+                    "api_identifier": API_IDENTIFIER,
+                }
 
     # Attach known modality information
     for model, modalities in MODEL_MODALITIES.items():

--- a/src/pricing_service/scrapers/gemini.py
+++ b/src/pricing_service/scrapers/gemini.py
@@ -7,6 +7,7 @@ import requests
 from bs4 import BeautifulSoup
 
 GEMINI_PRICING_URL = "https://ai.google.dev/pricing"
+API_IDENTIFIER = "gemini"
 
 # Gemini models accept multimodal inputs (text, images, audio, video) and
 # produce text outputs.
@@ -43,5 +44,6 @@ def fetch_prices() -> Dict[str, Dict]:
                 "raw": rows,
                 "source": GEMINI_PRICING_URL,
                 "modalities": GEMINI_MODALITIES,
+                "api_identifier": API_IDENTIFIER,
             }
     return data

--- a/src/pricing_service/scrapers/hedra.py
+++ b/src/pricing_service/scrapers/hedra.py
@@ -11,6 +11,7 @@ from typing import Dict
 import requests
 
 HEDRA_PRICING_URL = "https://hedra.com/pricing"
+API_IDENTIFIER = "hedra"
 
 
 def fetch_prices() -> Dict[str, Dict]:
@@ -25,6 +26,7 @@ def fetch_prices() -> Dict[str, Dict]:
                 "raw": {"error": str(exc)},
                 "source": HEDRA_PRICING_URL,
                 "modalities": ["speech-to-video", "text-to-video"],
+                "api_identifier": API_IDENTIFIER,
             }
         }
 
@@ -34,5 +36,6 @@ def fetch_prices() -> Dict[str, Dict]:
             "raw": {"message": "Pricing page accessible but data not parsed"},
             "source": HEDRA_PRICING_URL,
             "modalities": ["speech-to-video", "text-to-video"],
+            "api_identifier": API_IDENTIFIER,
         }
     }

--- a/src/pricing_service/scrapers/openai.py
+++ b/src/pricing_service/scrapers/openai.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 import requests
 
 OPENAI_PRICING_URL = "https://openai.com/pricing"
+API_IDENTIFIER = "openai"
 
 # The OpenAI pricing page is served through a CDN that may reject
 # requests without typical browser headers.  Supplying a minimal
@@ -39,5 +40,6 @@ def fetch_prices() -> dict:
                 data[model_id] = {
                     "raw": record,
                     "source": OPENAI_PRICING_URL,
+                    "api_identifier": API_IDENTIFIER,
                 }
     return data

--- a/src/pricing_service/scrapers/runway.py
+++ b/src/pricing_service/scrapers/runway.py
@@ -8,6 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 RUNWAY_PRICING_URL = "https://runwayml.com/pricing"
+API_IDENTIFIER = "runway"
 
 
 def fetch_prices() -> Dict[str, Dict]:
@@ -25,6 +26,7 @@ def fetch_prices() -> Dict[str, Dict]:
             "raw": {"Plan": "Free", "Price": free_price.strip()},
             "source": RUNWAY_PRICING_URL,
             "modalities": ["text-to-video", "image-to-video"],
+            "api_identifier": API_IDENTIFIER,
         }
 
     # Remaining plan prices are comment wrapped like "$<!-- -->12"
@@ -62,6 +64,7 @@ def fetch_prices() -> Dict[str, Dict]:
             },
             "source": RUNWAY_PRICING_URL,
             "modalities": ["text-to-video", "image-to-video"],
+            "api_identifier": API_IDENTIFIER,
         }
 
     # Team plan price only (usage cost not derivable without credits)
@@ -70,6 +73,7 @@ def fetch_prices() -> Dict[str, Dict]:
             "raw": {"Plan": "Team", "Price": f"${prices[2]}"},
             "source": RUNWAY_PRICING_URL,
             "modalities": ["text-to-video", "image-to-video"],
+            "api_identifier": API_IDENTIFIER,
         }
 
     return data


### PR DESCRIPTION
## Summary
- attach provider `api_identifier` to each pricing record
- document API identifiers and update sample data

## Testing
- `PYTHONPATH=src python -m pricing_service.scraper`

------
https://chatgpt.com/codex/tasks/task_e_68b23472c6b8832ab64196aaf702661a