### PR TITLE
feat: filter API endpoints

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -27,7 +27,13 @@ curl -I http://localhost:8001/
 ### 2. Get All Pricing Data
 **GET** `/api/pricing`
 
-Returns all available pricing data from all scrapers.
+Returns all available pricing data from all scrapers. Supports optional filtering by service type.
+
+**Query Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `service_type` | string | Filter results by service type (e.g. `api_endpoint`, `server_rental`, `subscription`) |
 
 **Response:**
 - **Status:** 200 OK
@@ -59,7 +65,11 @@ Returns all available pricing data from all scrapers.
 
 **Example:**
 ```bash
+# All services
 curl http://localhost:8001/api/pricing
+
+# Only API endpoints
+curl http://localhost:8001/api/pricing?service_type=api_endpoint
 ```
 
 **Empty Response (when no data available):**
@@ -154,7 +164,8 @@ Each model in the pricing data follows this structure:
       // ... other fields
     },
     "source": "https://provider.com/pricing",
-    "api_identifier": "provider"
+    "api_identifier": "provider",
+    "service_type": "api_endpoint"
   }
 }
 ```
@@ -163,6 +174,7 @@ Each model in the pricing data follows this structure:
 While the exact structure varies by provider, common fields include:
 
 - `api_identifier`: Provider's API identifier
+- `service_type`: Classification of the entry (`api_endpoint`, `server_rental`, `subscription`, etc.)
 - `Model`: Model name/identifier
 - `Input`: Input token pricing
 - `Output`: Output token pricing

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This service scrapes model pricing information from various providers and serves it over a FastAPI server. Each pricing record includes an `api_identifier` field that names the provider's API so other applications can associate models with their source service.
 
+Entries are now classified by `service_type` to distinguish API endpoints from other offerings such as subscriptions or server rentals. The API and web UI can filter to show only API endpoints.
+
 ## Running
 
 ```bash
@@ -10,7 +12,7 @@ python -m pricing_service.server
 ```
 
 The server exposes:
-- `GET /api/pricing` – list all pricing records
+- `GET /api/pricing` – list all pricing records (use `?service_type=api_endpoint` to filter APIs)
 - `GET /api/pricing/{model_id}` – retrieve pricing for a single model
 
 The service periodically refreshes pricing data every 6 hours using the included scraper modules.
@@ -23,3 +25,4 @@ The service includes a web interface for exploring pricing data. Navigate to `/u
 - Click any column header to sort by that column.
 - Toggle dark mode using the button in the controls.
 - Show or hide pricing columns with the column checkboxes.
+- Limit results to API endpoints using the "API endpoints only" toggle.

--- a/SCRAPER_GUIDE.md
+++ b/SCRAPER_GUIDE.md
@@ -11,7 +11,7 @@ This guide explains how to create, maintain, and troubleshoot scrapers for the p
 - `fal.py` - Placeholder scraper for fal.ai
 
 ### Scraper Interface
-All scrapers must implement the following interface:
+All scrapers must implement the following interface and classify each entry with a `service_type` value (for example `api_endpoint`, `server_rental`, or `subscription`):
 
 ```python
 def fetch_prices() -> dict:
@@ -20,7 +20,7 @@ def fetch_prices() -> dict:
     
     Returns:
         dict: Dictionary with model IDs as keys and pricing data as values.
-              Format: {model_id: {"raw": data, "source": url}}
+              Format: {model_id: {"raw": data, "source": url, "service_type": str}}
     """
 ```
 

--- a/data/model_pricing.json
+++ b/data/model_pricing.json
@@ -7,7 +7,8 @@
       "Price per second": "$0.0005/s"
     },
     "source": "https://fal.ai/pricing",
-    "api_identifier": "fal"
+    "api_identifier": "fal",
+    "service_type": "server_rental"
   },
   "H200": {
     "raw": {
@@ -17,7 +18,8 @@
       "Price per second": "$0.0006/s"
     },
     "source": "https://fal.ai/pricing",
-    "api_identifier": "fal"
+    "api_identifier": "fal",
+    "service_type": "server_rental"
   },
   "A100": {
     "raw": {
@@ -27,7 +29,8 @@
       "Price per second": "$0.0003/s"
     },
     "source": "https://fal.ai/pricing",
-    "api_identifier": "fal"
+    "api_identifier": "fal",
+    "service_type": "server_rental"
   },
   "B200": {
     "raw": {
@@ -37,7 +40,8 @@
       "Price per second": "contact us"
     },
     "source": "https://fal.ai/pricing",
-    "api_identifier": "fal"
+    "api_identifier": "fal",
+    "service_type": "server_rental"
   },
   "Hunyuan Video": {
     "raw": {
@@ -48,6 +52,7 @@
     },
     "source": "https://fal.ai/pricing",
     "api_identifier": "fal",
+    "service_type": "api_endpoint",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -62,6 +67,7 @@
     },
     "source": "https://fal.ai/pricing",
     "api_identifier": "fal",
+    "service_type": "api_endpoint",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -76,6 +82,7 @@
     },
     "source": "https://fal.ai/pricing",
     "api_identifier": "fal",
+    "service_type": "api_endpoint",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -90,6 +97,7 @@
     },
     "source": "https://fal.ai/pricing",
     "api_identifier": "fal",
+    "service_type": "api_endpoint",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -104,6 +112,7 @@
     },
     "source": "https://fal.ai/pricing",
     "api_identifier": "fal",
+    "service_type": "api_endpoint",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -118,6 +127,7 @@
     },
     "source": "https://fal.ai/pricing",
     "api_identifier": "fal",
+    "service_type": "api_endpoint",
     "modalities": [
       "text-to-video",
       "image-to-video"
@@ -133,7 +143,8 @@
       "text-to-video",
       "image-to-video"
     ],
-    "api_identifier": "runway"
+    "api_identifier": "runway",
+    "service_type": "subscription"
   },
   "runway-standard": {
     "raw": {
@@ -147,7 +158,8 @@
       "text-to-video",
       "image-to-video"
     ],
-    "api_identifier": "runway"
+    "api_identifier": "runway",
+    "service_type": "subscription"
   },
   "runway-pro": {
     "raw": {
@@ -161,7 +173,8 @@
       "text-to-video",
       "image-to-video"
     ],
-    "api_identifier": "runway"
+    "api_identifier": "runway",
+    "service_type": "subscription"
   },
   "runway-team": {
     "raw": {
@@ -173,7 +186,8 @@
       "text-to-video",
       "image-to-video"
     ],
-    "api_identifier": "runway"
+    "api_identifier": "runway",
+    "service_type": "subscription"
   },
   "hedra": {
     "raw": {
@@ -184,7 +198,8 @@
       "speech-to-video",
       "text-to-video"
     ],
-    "api_identifier": "hedra"
+    "api_identifier": "hedra",
+    "service_type": "api_endpoint"
   },
   "elevenlabs-free": {
     "raw": {
@@ -197,7 +212,8 @@
       "text-to-speech",
       "speech-to-speech"
     ],
-    "api_identifier": "elevenlabs"
+    "api_identifier": "elevenlabs",
+    "service_type": "subscription"
   },
   "elevenlabs-starter": {
     "raw": {
@@ -210,7 +226,8 @@
       "text-to-speech",
       "speech-to-speech"
     ],
-    "api_identifier": "elevenlabs"
+    "api_identifier": "elevenlabs",
+    "service_type": "subscription"
   },
   "elevenlabs-creator": {
     "raw": {
@@ -223,7 +240,8 @@
       "text-to-speech",
       "speech-to-speech"
     ],
-    "api_identifier": "elevenlabs"
+    "api_identifier": "elevenlabs",
+    "service_type": "subscription"
   },
   "elevenlabs-pro": {
     "raw": {
@@ -236,7 +254,8 @@
       "text-to-speech",
       "speech-to-speech"
     ],
-    "api_identifier": "elevenlabs"
+    "api_identifier": "elevenlabs",
+    "service_type": "subscription"
   },
   "elevenlabs-scale": {
     "raw": {
@@ -248,7 +267,8 @@
       "text-to-speech",
       "speech-to-speech"
     ],
-    "api_identifier": "elevenlabs"
+    "api_identifier": "elevenlabs",
+    "service_type": "subscription"
   },
   "elevenlabs-business": {
     "raw": {
@@ -260,7 +280,8 @@
       "text-to-speech",
       "speech-to-speech"
     ],
-    "api_identifier": "elevenlabs"
+    "api_identifier": "elevenlabs",
+    "service_type": "subscription"
   },
   "Gemini 2.5 Pro": {
     "raw": {
@@ -292,7 +313,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.5 Flash": {
     "raw": {
@@ -328,7 +350,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.5 Flash-Lite": {
     "raw": {
@@ -360,7 +383,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.5 Flash Native Audio": {
     "raw": {
@@ -384,7 +408,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.5 Flash Image Preview": {
     "raw": {
@@ -408,7 +433,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.5 Flash Preview TTS": {
     "raw": {
@@ -432,7 +458,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.5 Pro Preview TTS": {
     "raw": {
@@ -456,7 +483,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.0 Flash": {
     "raw": {
@@ -504,7 +532,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 2.0 Flash-Lite": {
     "raw": {
@@ -544,7 +573,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Imagen 4": {
     "raw": {
@@ -572,7 +602,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Imagen 3": {
     "raw": {
@@ -592,7 +623,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Veo 3 Preview": {
     "raw": {
@@ -612,7 +644,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Veo 3 Fast Preview": {
     "raw": {
@@ -632,7 +665,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Veo 2": {
     "raw": {
@@ -652,7 +686,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini Embedding": {
     "raw": {
@@ -672,7 +707,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemma 3": {
     "raw": {
@@ -712,7 +748,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemma 3n": {
     "raw": {
@@ -752,7 +789,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 1.5 Flash": {
     "raw": {
@@ -792,7 +830,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 1.5 Flash-8B": {
     "raw": {
@@ -832,7 +871,8 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   },
   "Gemini 1.5 Pro": {
     "raw": {
@@ -872,6 +912,7 @@
       "audio-to-text",
       "video-to-text"
     ],
-    "api_identifier": "gemini"
+    "api_identifier": "gemini",
+    "service_type": "api_endpoint"
   }
 }

--- a/src/pricing_service/scrapers/elevenlabs.py
+++ b/src/pricing_service/scrapers/elevenlabs.py
@@ -46,5 +46,6 @@ def fetch_prices() -> Dict[str, Dict]:
             "source": ELEVENLABS_PRICING_URL,
             "modalities": ["text-to-speech", "speech-to-speech"],
             "api_identifier": API_IDENTIFIER,
+            "service_type": "subscription",
         }
     return data

--- a/src/pricing_service/scrapers/fal.py
+++ b/src/pricing_service/scrapers/fal.py
@@ -54,6 +54,7 @@ def fetch_prices() -> dict:
                 "raw": record,
                 "source": FAL_PRICING_URL,
                 "api_identifier": API_IDENTIFIER,
+                "service_type": "server_rental",
             }
 
     # Model pricing (second table)
@@ -65,6 +66,7 @@ def fetch_prices() -> dict:
                     "raw": record,
                     "source": FAL_PRICING_URL,
                     "api_identifier": API_IDENTIFIER,
+                    "service_type": "api_endpoint",
                 }
 
     # Attach known modality information

--- a/src/pricing_service/scrapers/gemini.py
+++ b/src/pricing_service/scrapers/gemini.py
@@ -45,5 +45,6 @@ def fetch_prices() -> Dict[str, Dict]:
                 "source": GEMINI_PRICING_URL,
                 "modalities": GEMINI_MODALITIES,
                 "api_identifier": API_IDENTIFIER,
+                "service_type": "api_endpoint",
             }
     return data

--- a/src/pricing_service/scrapers/hedra.py
+++ b/src/pricing_service/scrapers/hedra.py
@@ -27,6 +27,7 @@ def fetch_prices() -> Dict[str, Dict]:
                 "source": HEDRA_PRICING_URL,
                 "modalities": ["speech-to-video", "text-to-video"],
                 "api_identifier": API_IDENTIFIER,
+                "service_type": "api_endpoint",
             }
         }
 
@@ -37,5 +38,6 @@ def fetch_prices() -> Dict[str, Dict]:
             "source": HEDRA_PRICING_URL,
             "modalities": ["speech-to-video", "text-to-video"],
             "api_identifier": API_IDENTIFIER,
+            "service_type": "api_endpoint",
         }
     }

--- a/src/pricing_service/scrapers/openai.py
+++ b/src/pricing_service/scrapers/openai.py
@@ -30,6 +30,7 @@ def fetch_prices() -> dict:
     # contain pricing information.
     for card in soup.select("table"):
         headers = [th.get_text(strip=True) for th in card.select("thead th")]
+        service_type = "api_endpoint" if "Model" in headers else "other_service"
         for row in card.select("tbody tr"):
             cols = [td.get_text(strip=True) for td in row.select("td")]
             if len(cols) != len(headers):
@@ -41,5 +42,6 @@ def fetch_prices() -> dict:
                     "raw": record,
                     "source": OPENAI_PRICING_URL,
                     "api_identifier": API_IDENTIFIER,
+                    "service_type": service_type,
                 }
     return data

--- a/src/pricing_service/scrapers/runway.py
+++ b/src/pricing_service/scrapers/runway.py
@@ -27,6 +27,7 @@ def fetch_prices() -> Dict[str, Dict]:
             "source": RUNWAY_PRICING_URL,
             "modalities": ["text-to-video", "image-to-video"],
             "api_identifier": API_IDENTIFIER,
+            "service_type": "subscription",
         }
 
     # Remaining plan prices are comment wrapped like "$<!-- -->12"
@@ -65,6 +66,7 @@ def fetch_prices() -> Dict[str, Dict]:
             "source": RUNWAY_PRICING_URL,
             "modalities": ["text-to-video", "image-to-video"],
             "api_identifier": API_IDENTIFIER,
+            "service_type": "subscription",
         }
 
     # Team plan price only (usage cost not derivable without credits)
@@ -74,6 +76,7 @@ def fetch_prices() -> Dict[str, Dict]:
             "source": RUNWAY_PRICING_URL,
             "modalities": ["text-to-video", "image-to-video"],
             "api_identifier": API_IDENTIFIER,
+            "service_type": "subscription",
         }
 
     return data

--- a/src/pricing_service/server.py
+++ b/src/pricing_service/server.py
@@ -60,8 +60,11 @@ async def startup_event() -> None:
 
 
 @app.get("/api/pricing")
-async def get_pricing() -> Dict[str, dict]:
-    return _cache or {}
+async def get_pricing(service_type: str | None = None) -> Dict[str, dict]:
+    data = _cache or {}
+    if service_type:
+        return {k: v for k, v in data.items() if v.get("service_type") == service_type}
+    return data
 
 
 @app.get("/api/pricing/{model_id}")

--- a/ui/index.html
+++ b/ui/index.html
@@ -67,6 +67,12 @@
             overflow-y: auto;
             border: 1px solid #ddd;
         }
+        .api-toggle {
+            font-size: 12px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
         .dropdown-content.show {
             display: block;
         }
@@ -425,6 +431,7 @@
                 <!-- Provider list will be populated here -->
             </div>
         </div>
+        <label class="api-toggle"><input type="checkbox" id="apiFilter" onchange="filterTable()"> API endpoints only</label>
         <button id="themeToggle" class="toggle-btn">Toggle Dark Mode</button>
     </div>
 
@@ -482,11 +489,11 @@
         // Function to get service type label
         function getServiceType(modelId, details, modalities) {
             if (isServerRental(modelId, details)) {
-                return 'Server/GPU Rental';
+                return 'server_rental';
             } else if (modalities && modalities.length > 0) {
-                return 'AI Model/API';
+                return 'api_endpoint';
             } else {
-                return 'Service';
+                return 'other_service';
             }
         }
 
@@ -529,7 +536,7 @@
                         details: modelData.raw || {},
                         source: modelData.source || '',
                         modalities: modalities,
-                        serviceType: getServiceType(modelId, modelData.raw || {}, modalities),
+                        serviceType: modelData.service_type || getServiceType(modelId, modelData.raw || {}, modalities),
                         apiIdentifier: modelData.api_identifier || 'unknown'
                     };
                 });
@@ -566,8 +573,8 @@
             const statsDiv = document.getElementById('stats');
             const totalModels = tableData.length;
             const totalModalities = allModalities.size;
-            const serverRentals = tableData.filter(item => item.modalities.includes('server')).length;
-            const aiModels = tableData.filter(item => !item.modalities.includes('server')).length;
+            const apiEndpoints = tableData.filter(item => item.serviceType === 'api_endpoint').length;
+            const serverRentals = tableData.filter(item => item.serviceType === 'server_rental').length;
             const totalProviders = allProviders.size;
 
             statsDiv.innerHTML = `
@@ -576,8 +583,8 @@
                     <div class="stat-label">Total Services</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-number">${aiModels}</div>
-                    <div class="stat-label">AI Models/APIs</div>
+                    <div class="stat-number">${apiEndpoints}</div>
+                    <div class="stat-label">API Endpoints</div>
                 </div>
                 <div class="stat-card">
                     <div class="stat-number">${serverRentals}</div>
@@ -955,6 +962,7 @@
         function filterTable() {
             const query = document.getElementById('searchInput').value.toLowerCase();
             
+            const apiOnly = document.getElementById('apiFilter').checked;
             let filtered = tableData.filter(item => {
                 // Text search
                 const modelMatch = item.modelId.toLowerCase().includes(query);
@@ -970,7 +978,9 @@
                 const modalityMatch = selectedModalities.size === 0 || 
                     item.modalities.some(modality => selectedModalities.has(modality));
                 
-                return textMatch && modalityMatch;
+                const serviceMatch = !apiOnly || item.serviceType === 'api_endpoint';
+
+                return textMatch && modalityMatch && serviceMatch;
             });
             
             renderTable(filtered);


### PR DESCRIPTION
## Summary
- classify pricing entries by `service_type`
- add API endpoint filters to backend and UI
- document service type filtering

## Testing
- `PYTHONPATH=src python -m pricing_service.scraper`
- `PYTHONPATH=src uvicorn pricing_service.server:app --port 8000` (in another shell)
- `curl -s "http://127.0.0.1:8000/api/pricing?service_type=api_endpoint" | python -m json.tool | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b23ef2e804832a8cb91fe6c9873f2e